### PR TITLE
PERF: Optimize Reader.TypeDeserializerCache.cs

### DIFF
--- a/src/XmlGridReader.Benchmarks/Benchmarks.cs
+++ b/src/XmlGridReader.Benchmarks/Benchmarks.cs
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Mathematics;
 namespace XmlGridReader.Benchmarks
 {
     [RankColumn(NumeralSystem.Arabic)]
+    [MemoryDiagnoser]
     public class Benchmarks
     {
         private string xml;

--- a/src/XmlGridReader/Reader.TypeDeserializerCache.cs
+++ b/src/XmlGridReader/Reader.TypeDeserializerCache.cs
@@ -44,7 +44,7 @@ namespace XmlGridReader
             {
                 reader.ReadRow();
 
-                if (!reader.Columns.Any())
+                if (reader.Columns.Count == 0)
                 {
                     throw new InvalidOperationException("No columns");
                 }
@@ -97,12 +97,12 @@ namespace XmlGridReader
 
             public bool Equals(DeserializerKey other)
             {
-                if (hashCode != other.hashCode || fields.Count() != other.fields.Count())
+                if (hashCode != other.hashCode || fields.Count != other.fields.Count)
                 {
                     return false;
                 }
 
-                for (int i = 0; i < fields.Count(); i++)
+                for (int i = 0; i < fields.Count; i++)
                 {
                     if (fields[i] != other.fields[i])
                     {


### PR DESCRIPTION
Hi @bdlane, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                    Method | NumberOfRecords |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD | Rank |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------------- |---------:|----------:|----------:|---------:|------:|--------:|-----:|--------:|--------:|------:|----------:|
|             XmlSerializer |            1000 | 3.843 ms | 0.2893 ms | 0.8529 ms | 3.636 ms |  1.00 |    0.00 |    2 | 70.3125 | 35.1563 |     - | 310.18 KB |
|                 LinqToXml |            1000 | 5.057 ms | 0.3136 ms | 0.9247 ms | 5.369 ms |  1.39 |    0.40 |    4 | 93.7500 | 46.8750 |     - |  527.9 KB |
|                 XmlReader |            1000 | 2.755 ms | 0.2076 ms | 0.6120 ms | 2.692 ms |  0.75 |    0.22 |    1 | 62.5000 | 27.3438 |     - | 277.52 KB |
|  XmlGridReader_Properties |            1000 | 4.110 ms | 0.2972 ms | 0.8762 ms | 4.069 ms |  1.12 |    0.35 |    3 | 74.2188 | 31.2500 |     - | 332.53 KB |
| XmlGridReader_Constructor |            1000 | 4.080 ms | 0.2659 ms | 0.7840 ms | 4.170 ms |  1.11 |    0.33 |    3 | 74.2188 | 31.2500 |     - | 332.53 KB |

**Benchmarks after changes:**
|                    Method | NumberOfRecords |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD | Rank |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------------- |---------:|----------:|----------:|---------:|------:|--------:|-----:|--------:|--------:|------:|----------:|
|             XmlSerializer |            1000 | 2.724 ms | 0.0842 ms | 0.2319 ms | 2.632 ms |  1.00 |    0.00 |    4 | 70.3125 | 31.2500 |     - | 310.18 KB |
|                 LinqToXml |            1000 | 3.018 ms | 0.0578 ms | 0.1351 ms | 2.978 ms |  1.10 |    0.10 |    5 | 93.7500 | 46.8750 |     - |  527.9 KB |
|                 XmlReader |            1000 | 1.682 ms | 0.0266 ms | 0.0222 ms | 1.681 ms |  0.57 |    0.06 |    1 | 58.5938 | 27.3438 |     - | 277.54 KB |
|  XmlGridReader_Properties |            1000 | 2.494 ms | 0.0489 ms | 0.0523 ms | 2.476 ms |  0.85 |    0.07 |    2 | 78.1250 | 31.2500 |     - | 332.49 KB |
| XmlGridReader_Constructor |            1000 | 2.600 ms | 0.0516 ms | 0.1322 ms | 2.564 ms |  0.95 |    0.09 |    3 | 70.3125 | 27.3438 |     - | 332.49 KB |

As you can see the duration and allocations (Properties and Constructor benchmarks) have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!